### PR TITLE
Add fixed PCI-slot number in VM config file.

### DIFF
--- a/lib/vm-run
+++ b/lib/vm-run
@@ -563,103 +563,25 @@ vm::bhyve_device_disks(){
 # @modifies _devices _slot_network _taplist
 #
 vm::bhyve_device_networking(){
-    local _type _switch _mac _custom_tap _tap _sid _mtu
-    local _num=0 _member_type _sw_type _iname _func=0
+    local _emulation _num=0 _func=0
 
     while true; do
-        config::get "_type" "network${_num}_type"
-        [ -z "${_type}" ] && break
-
-        config::get "_switch" "network${_num}_switch"
-        config::get "_mac" "network${_num}_mac"
-        config::get "_custom_tap" "network${_num}_device"
-        config::get "_iname" "network${_num}_name"
+        config::get "_emulation" "network${_num}_type"
+        [ -z "${_emulation}" ] && break
         config::get "_slot" "network${_num}_slot"
-
-        # set a static mac if we don't have one
-        [ -z "${_mac}" ] && vm::generate_static_mac
 
         if [ -n "${_slot}" ]; then
             _slot_network=${_slot}
             _func=0
         else
+            # move slot if we've hit function 8
             if [ ${_func} -ge 8 ]; then
                 _func=0
-                _slot_network=$((_slot_network + 1))
-            fi
-        fi 
-
-        # get type of switch
-        switch::type "_sw_type" "${_switch}"
-
-        if [ "${_sw_type}" = "vale" ]; then
-            # create a vale port id
-            switch::vale::id "_tap" "${_switch}" "${_mac}"
-
-            util::log "guest" "${_name}" "adding vale interface ${_tap} (${_switch})"
-            _devices="${_devices} -s ${_slot_network}:${_func},${_type},${_tap}"
-            [ -n "${_mac}" ] && _devices="${_devices},mac=${_mac}"
-
-            _func=$((_func + 1))
-        elif [ "${_sw_type}" = "netgraph" ]; then
-            # create a netgraph peer
-            switch::netgraph::id "_path" "${_switch}"
-
-            util::log "guest" "${_name}" "adding netgraph interface ${_path} (${_switch})"
-            _devices="${_devices} -s ${_slot_network}:${_func},${_type},${_path}"
-            [ -n "${_mac}" ] && _devices="${_devices},mac=${_mac}"
-
-            _func=$((_func + 1))
-        else
-            # create interface
-            if [ -n "${_custom_tap}" ]; then
-                _tap="${_custom_tap}"
-            elif [ -n "${_iname}" ]; then
-                _tap=$(ifconfig tap create name "${_iname}")
-            else
-                _tap=$(ifconfig tap create)
-            fi
-
-            # should this be a span member?
-            _member_type="addm"
-            config::yesno "network${_num}_span" && _member_type="span"
-
-            if [ -n "${_tap}" ]; then
-                util::log "guest" "${_name}" "initialising network device ${_tap}"
-                ifconfig "${_tap}" descr "vmnet/${_name}/${_num}/${_switch:-custom}" group vm-port >/dev/null 2>&1
-
-                if [ -n "${_switch}" ]; then
-                    switch::id "_sid" "${_switch}"
-
-                    if [ -n "${_sid}" ]; then
-                        _mtu=$(ifconfig "${_sid}" | head -n1 | awk '{print $NF}')
-
-                        if [ "${_mtu}" != "1500" ]; then
-                            util::log "guest" "${_name}" "setting mtu of ${_tap} to ${_mtu}"
-                    	    ifconfig "${_tap}" mtu "${_mtu}" >/dev/null 2>&1
-                        fi
-
-                        util::log "guest" "${_name}" "adding ${_tap} -> ${_sid} (${_switch} ${_member_type})"
-                        ifconfig "${_sid}" "${_member_type}" "${_tap}" >/dev/null 2>&1 || util::log "guest" "${_name}" "failed to add ${_tap} to ${_sid}"
-
-                        util::log "guest" "${_name}" "bring up ${_tap} -> ${_sid} (${_switch} ${_member_type})"
-                        ifconfig "${_tap}" up >/dev/null 2>&1 || util::log "guest" "${_name}" "failed to bring up ${_tap} in ${_sid}"
-
-                        # set private if configured
-                        switch::is_private "${_switch}" && ifconfig "${_sid}" "private" "${_tap}" >/dev/null 2>&1
-                    else
-                        util::log "guest" "${_name}" "failed to find virtual switch '${_switch}'"
-                    fi
-                fi
-
-                _devices="${_devices} -s ${_slot_network}:${_func},${_type},${_tap}"
-                [ -n "${_mac}" ] && _devices="${_devices},mac=${_mac}"
-
-                _func=$((_func + 1))
-                [ -z "${_custom_tap}" ] && _taplist="${_taplist}${_taplist:+ }${_tap}"
+                _slot=$((_slot + 1))
             fi
         fi
 
+        switch::provision
         _num=$((_num + 1))
     done
 }
@@ -760,11 +682,16 @@ vm::bhyve_device_mouse(){
 }
 
 vm::bhyve_device_sound(){
-    local _play
+    local _play _rec
     config::get "_play" "sound_play" "/dev/dsp0"
+    config::get "_rec" "sound_rec"
 
     if config::yesno "sound"; then
         _devices="${_devices} -s ${_slot_sound}:0,hda,play=${_play}"
+
+        if [ -n "${_rec}" ]; then
+            _devices="${_devices},rec=${_rec}"
+        fi
     fi
 }
 

--- a/lib/vm-run
+++ b/lib/vm-run
@@ -36,9 +36,10 @@ vm::run(){
     local _name _iso _iso_dev
     local _cpu _memory _bootdisk _bootdisk_dev _guest _wiredmem
     local _guest_support _uefi _uuid _debug _hostbridge _loader
-    local _opts _devices _slot _install_slot _func=0 _taplist _exit _passdev
+    local _opts _devices _func=0 _taplist _exit _passdev
     local _com _comports _comstring _logpath="/dev/null" _run=1
     local _bhyve_options _action
+    local _slot_hostbridge _slot_install _slot_disks _slot_network _slot_passthru _slot_rand _slot_console _slot_sound _slot_xhci _slot_fbuf _slot_lpc
 
     cmd::parse_args "$@"
     shift $?
@@ -61,8 +62,17 @@ vm::run(){
     config::get "_uuid" "uuid"
     config::get "_debug" "debug" "no"
     config::get "_bhyve_options" "bhyve_options"
-    config::get "_slot" "start_slot" "4"
-    config::get "_install_slot" "install_slot" "3"
+    config::get "_slot_hostbridge" "hostbridge_slot" "0"
+    config::get "_slot_install" "install_slot" "3"
+    config::get "_slot_disks" "disk_slot_start" "4"
+    config::get "_slot_network" "network_slot_start" "15"
+    config::get "_slot_passthru" "passthru_slot_start" "20"
+    config::get "_slot_rand" "virt_random_slot" "26"
+    config::get "_slot_console" "virt_console_slot" "27"
+    config::get "_slot_sound" "sound_slot" "28"
+    config::get "_slot_xhci" "xhci_slot" "29"
+    config::get "_slot_fbuf" "fbuf_slot" "30"
+    config::get "_slot_lpc" "lpc_slot" "31"
 
     # generate a uuid if we don't have one already
     if [ -z "${_uuid}" ]; then
@@ -193,16 +203,16 @@ vm::run(){
         # add install iso or disk image
         if [ -n "${_iso}" ]; then
             if echo "${_iso}" | grep -iqs '.iso$'; then
-                _iso_dev="-s ${_install_slot}:0,ahci-cd,${_iso},ro"
+                _iso_dev="-s ${_slot_install}:0,ahci-cd,${_iso},ro"
             else
-                _iso_dev="-s ${_install_slot}:0,ahci-hd,${_iso},ro"
+                _iso_dev="-s ${_slot_install}:0,ahci-hd,${_iso},ro"
             fi
         fi
 
         # use null.iso if not an install and uefi firmware
         # old instructions but some windows versions apparently needed this present
         [ -z "${_iso}" -a "${_loader}" = "uefi" ] && config::yesno "nulliso_fix" && \
-            _iso_dev="-s ${_install_slot}:0,ahci-cd,${vm_dir}/.config/null.iso"
+            _iso_dev="-s ${_slot_install}:0,ahci-cd,${vm_dir}/.config/null.iso"
 
         # reasonably ugly hack to remove wait option after first run
         [ "${_run}" -eq "2" ] && vm::bhyve_device_fbuf_clear_wait
@@ -424,12 +434,12 @@ vm::bhyve_device_basic(){
     # add hostbridge
     case "$_hostbridge" in 
         no*) ;;
-        amd) _devices="-s 0,amd_hostbridge" ;;
-        *)   _devices="-s 0,hostbridge" ;;
+        amd) _devices="-s ${_slot_hostbridge},amd_hostbridge" ;;
+        *)   _devices="-s ${_slot_hostbridge},hostbridge" ;;
     esac
 
     # lpc
-    _devices="${_devices}${_devices:+ }-s 31,lpc"
+    _devices="${_devices}${_devices:+ }-s ${_slot_lpc},lpc"
 }
 
 # get bhyve device string for disk devices
@@ -444,12 +454,12 @@ vm::bhyve_device_basic(){
 # this can be overridden by setting the ahci_device_limit
 # guest option to an integer between 2 and 32.
 #
-# @modifies _devices _slot
+# @modifies _devices _slot_disks
 #
 vm::bhyve_device_disks(){
     local _disk _type _dev _path _opts _ahci _atype
     local _ahci_num=0 _num=0 _add _ahci_multi
-    local _ahci_limit=1
+    local _ahci_limit=1 _func=0
 
     # check if user has set a per-controller device limit
     config::get "_ahci_multi" "ahci_device_limit"
@@ -476,10 +486,16 @@ vm::bhyve_device_disks(){
 
         config::get "_dev" "disk${_num}_dev"
         config::get "_opts" "disk${_num}_opts"
+        config::get "_slot" "disk${_num}_slot"
 
-        if [ ${_func} -ge 8 ]; then
-            _func=0
-            _slot=$((_slot + 1))
+        if [ -n "${_slot}" ]; then
+             _func=0
+            _slot_disks=${_slot}
+        else
+            if [ ${_func} -ge 8 ]; then
+                _func=0
+                _slot_disks=$((_slot_disks + 1))
+            fi
         fi
 
         vm::get_disk_path "_path" "${_name}" "${_disk}" "${_dev}"
@@ -500,7 +516,7 @@ vm::bhyve_device_disks(){
 
                     # we need to move to another controller if we get to the limit
                     if [ ${_ahci_num} -ge ${_ahci_limit} ]; then
-                        _devices="${_devices} -s ${_slot}:${_func},ahci${_ahci}"
+                        _devices="${_devices} -s ${_slot_disks}:${_func},ahci${_ahci}"
                         _ahci=""
                         _ahci_num=0
                         _add=1
@@ -511,7 +527,7 @@ vm::bhyve_device_disks(){
             _atype=""
         else
 
-            _devices="${_devices} -s ${_slot}:${_func},${_type},${_path}"
+            _devices="${_devices} -s ${_slot_disks}:${_func},${_type},${_path}"
             [ -n "${_opts}" ] && _devices="${_devices},${_opts}"
             _add=1
         fi
@@ -519,7 +535,7 @@ vm::bhyve_device_disks(){
         # have we just added a device?
         if [ -n "${_add}" ]; then
             if [ -n "${_uefi}" ]; then
-                _slot=$((_slot + 1))
+                _slot_disks=$((_slot_disks + 1))
 
             else
                 _func=$((_func + 1))
@@ -533,15 +549,8 @@ vm::bhyve_device_disks(){
 
     # have ahci devices left?
     if [ -n "${_ahci}" ]; then
-        _devices="${_devices} -s ${_slot}:${_func},ahci${_ahci}"
-        [ -n "${_uefi}" ] && _slot=$((_slot + 1))
-    fi
-
-    # move to next slot if we have devices
-    # unless uefi as we already inc slot in uefi mode
-    if [ ${_num} -ge 1 -a -z "${_uefi}" ]; then
-        _slot=$((_slot + 1))
-        _func=0
+        _devices="${_devices} -s ${_slot_disks}:${_func},ahci${_ahci}"
+        [ -n "${_uefi}" ] && _slot_disks=$((_slot_disks + 1))
     fi
 }
 
@@ -551,40 +560,118 @@ vm::bhyve_device_disks(){
 # we add each tap to __taplist from vm::run which it will
 # use to desstroy them all on shutdown
 #
-# @modifies _devices _slot _taplist _func
+# @modifies _devices _slot_network _taplist
 #
 vm::bhyve_device_networking(){
-    local _emulation _num=0
+    local _type _switch _mac _custom_tap _tap _sid _mtu
+    local _num=0 _member_type _sw_type _iname _func=0
 
     while true; do
-        config::get "_emulation" "network${_num}_type"
-        [ -z "${_emulation}" ] && break
+        config::get "_type" "network${_num}_type"
+        [ -z "${_type}" ] && break
 
-        # move slot if we've hit function 8
-        if [ ${_func} -ge 8 ]; then
+        config::get "_switch" "network${_num}_switch"
+        config::get "_mac" "network${_num}_mac"
+        config::get "_custom_tap" "network${_num}_device"
+        config::get "_iname" "network${_num}_name"
+        config::get "_slot" "network${_num}_slot"
+
+        # set a static mac if we don't have one
+        [ -z "${_mac}" ] && vm::generate_static_mac
+
+        if [ -n "${_slot}" ]; then
+            _slot_network=${_slot}
             _func=0
-            _slot=$((_slot + 1))
+        else
+            if [ ${_func} -ge 8 ]; then
+                _func=0
+                _slot_network=$((_slot_network + 1))
+            fi
+        fi 
+
+        # get type of switch
+        switch::type "_sw_type" "${_switch}"
+
+        if [ "${_sw_type}" = "vale" ]; then
+            # create a vale port id
+            switch::vale::id "_tap" "${_switch}" "${_mac}"
+
+            util::log "guest" "${_name}" "adding vale interface ${_tap} (${_switch})"
+            _devices="${_devices} -s ${_slot_network}:${_func},${_type},${_tap}"
+            [ -n "${_mac}" ] && _devices="${_devices},mac=${_mac}"
+
+            _func=$((_func + 1))
+        elif [ "${_sw_type}" = "netgraph" ]; then
+            # create a netgraph peer
+            switch::netgraph::id "_path" "${_switch}"
+
+            util::log "guest" "${_name}" "adding netgraph interface ${_path} (${_switch})"
+            _devices="${_devices} -s ${_slot_network}:${_func},${_type},${_path}"
+            [ -n "${_mac}" ] && _devices="${_devices},mac=${_mac}"
+
+            _func=$((_func + 1))
+        else
+            # create interface
+            if [ -n "${_custom_tap}" ]; then
+                _tap="${_custom_tap}"
+            elif [ -n "${_iname}" ]; then
+                _tap=$(ifconfig tap create name "${_iname}")
+            else
+                _tap=$(ifconfig tap create)
+            fi
+
+            # should this be a span member?
+            _member_type="addm"
+            config::yesno "network${_num}_span" && _member_type="span"
+
+            if [ -n "${_tap}" ]; then
+                util::log "guest" "${_name}" "initialising network device ${_tap}"
+                ifconfig "${_tap}" descr "vmnet/${_name}/${_num}/${_switch:-custom}" group vm-port >/dev/null 2>&1
+
+                if [ -n "${_switch}" ]; then
+                    switch::id "_sid" "${_switch}"
+
+                    if [ -n "${_sid}" ]; then
+                        _mtu=$(ifconfig "${_sid}" | head -n1 | awk '{print $NF}')
+
+                        if [ "${_mtu}" != "1500" ]; then
+                            util::log "guest" "${_name}" "setting mtu of ${_tap} to ${_mtu}"
+                    	    ifconfig "${_tap}" mtu "${_mtu}" >/dev/null 2>&1
+                        fi
+
+                        util::log "guest" "${_name}" "adding ${_tap} -> ${_sid} (${_switch} ${_member_type})"
+                        ifconfig "${_sid}" "${_member_type}" "${_tap}" >/dev/null 2>&1 || util::log "guest" "${_name}" "failed to add ${_tap} to ${_sid}"
+
+                        util::log "guest" "${_name}" "bring up ${_tap} -> ${_sid} (${_switch} ${_member_type})"
+                        ifconfig "${_tap}" up >/dev/null 2>&1 || util::log "guest" "${_name}" "failed to bring up ${_tap} in ${_sid}"
+
+                        # set private if configured
+                        switch::is_private "${_switch}" && ifconfig "${_sid}" "private" "${_tap}" >/dev/null 2>&1
+                    else
+                        util::log "guest" "${_name}" "failed to find virtual switch '${_switch}'"
+                    fi
+                fi
+
+                _devices="${_devices} -s ${_slot_network}:${_func},${_type},${_tap}"
+                [ -n "${_mac}" ] && _devices="${_devices},mac=${_mac}"
+
+                _func=$((_func + 1))
+                [ -z "${_custom_tap}" ] && _taplist="${_taplist}${_taplist:+ }${_tap}"
+            fi
         fi
 
-        switch::provision
         _num=$((_num + 1))
     done
-
-    if [ ${_num} -ge 1 ]; then
-        _slot=$((_slot + 1))
-        _func=0
-    fi
 }
 
 # check if user wants a virtio-rand device
 #
-# @modifies _devices _slot
+# @modifies _devices _slot_rand
 #
 vm::bhyve_device_rand(){
 
     if config::yesno "virt_random"; then
-        _devices="${_devices} -s ${_slot}:0,virtio-rnd"
-        _slot=$((_slot + 1))
+        _devices="${_devices} -s ${_slot_rand}:0,virtio-rnd"
     fi
 }
 
@@ -641,8 +728,7 @@ vm::bhyve_device_fbuf(){
     echo "vnc=${_listen:-0.0.0.0}:${_port}" >> "${VM_DS_PATH}/${_name}/console"
 
     # add device
-    _devices="${_devices} -s ${_slot}:0,fbuf,${_fbuf_conf}"
-    _slot=$((_slot + 1))
+    _devices="${_devices} -s ${_slot_fbuf}:0,fbuf,${_fbuf_conf}"
 }
 
 # remove wait option if we're in auto mode
@@ -669,30 +755,22 @@ vm::bhyve_device_mouse(){
 
     # add a tablet device if enabled
     if config::yesno "xhci_mouse"; then
-        _devices="${_devices} -s ${_slot}:0,xhci,tablet"
-        _slot=$((_slot + 1))
+        _devices="${_devices} -s ${_slot_xhci}:0,xhci,tablet"
     fi
 }
 
 vm::bhyve_device_sound(){
-    local _play _rec
+    local _play
     config::get "_play" "sound_play" "/dev/dsp0"
-    config::get "_rec" "sound_rec"
 
     if config::yesno "sound"; then
-        _devices="${_devices} -s ${_slot}:0,hda,play=${_play}"
-
-        if [ -n "${_rec}" ]; then
-            _devices="${_devices},rec=${_rec}"
-        fi
-
-        _slot=$((_slot + 1))
+        _devices="${_devices} -s ${_slot_sound}:0,hda,play=${_play}"
     fi
 }
 
 # add virtio_console devices to the guest
 #
-# @modifies _devices _slot
+# @modifies _devices _slot_console
 #
 vm::bhyve_device_console(){
     local _console _curr=0
@@ -715,15 +793,14 @@ vm::bhyve_device_console(){
          config::get "_console" "virt_console${_curr}"
     done
 
-    _devices="${_devices} -s ${_slot}:0,virtio-console${_dev_str}"
-    _slot=$((_slot + 1))
+    _devices="${_devices} -s ${_slot_console}:0,virtio-console${_dev_str}"
 }
 
 # get any pci passthrough devices
 # FreeBSD 11 needs wired memory so update _opts in that case if
 # we have any pass through devices
 #
-# @modifies _devices _slot _opts _wiredmem
+# @modifies _devices _slot_passthru _opts _wiredmem
 #
 vm::bhyve_device_passthru(){
     local _dev _orig_slot _func=0
@@ -745,11 +822,11 @@ vm::bhyve_device_passthru(){
             # if user wants to passthru a device that has multiple functions which must stay together
             # on one slot, they should be together in configuration file
             if [ -n "${_last_orig_slot}" -a "${_last_orig_slot}" != "${_orig_slot}" ]; then
-                _slot=$((_slot + 1))
+                _slot_passthru=$((_slot_passthru + 1))
                 _func=0
             fi
 
-            _devices="${_devices} -s ${_slot}:${_func},passthru,${_dev}"
+            _devices="${_devices} -s ${_slot_passthru}:${_func},passthru,${_dev}"
             _last_orig_slot=${_orig_slot}
             _func=$((_func + 1))
         fi
@@ -758,8 +835,6 @@ vm::bhyve_device_passthru(){
     done
 
     if [ ${_num} -ge 1 ]; then
-        _slot=$((_slot + 1))
-
         # add wired memory for 10.3+
         [ ${VERSION_BSD} -ge 1003000 ] && _opts="${_opts} -S" && _wiredmem="1"
     fi

--- a/lib/vm-switch-netgraph
+++ b/lib/vm-switch-netgraph
@@ -112,7 +112,7 @@ switch::netgraph::provision(){
     switch::netgraph::id "_ngid" "${_switch}"
 
     util::log "guest" "${_name}" "adding netgraph interface ${_ngid} (${_switch})"
-    _devices="${_devices} -s ${_slot}:${_func},${_emulation},${_ngid}"
+    _devices="${_devices} -s ${_slot_network}:${_func},${_emulation},${_ngid}"
     [ -n "${_mac}" ] && _devices="${_devices},mac=${_mac}"
 
      _func=$((_func + 1))

--- a/lib/vm-switch-standard
+++ b/lib/vm-switch-standard
@@ -397,7 +397,7 @@ switch::standard::provision(){
         fi
     fi
 
-    _devices="${_devices} -s ${_slot}:${_func},${_emulation},${_tap}"
+    _devices="${_devices} -s ${_slot_network}:${_func},${_emulation},${_tap}"
     [ -n "${_mac}" ] && _devices="${_devices},mac=${_mac}"
 
     _func=$((_func + 1))

--- a/lib/vm-switch-vale
+++ b/lib/vm-switch-vale
@@ -121,7 +121,7 @@ switch::vale::provision(){
     switch::vale::id "_vale_id" "${_switch}" "${_mac}"
 
     util::log "guest" "${_name}" "adding vale interface ${_tap} (${_switch})"
-    _devices="${_devices} -s ${_slot}:${_func},${_emulation},${_vale_id}"
+    _devices="${_devices} -s ${_slot_network}:${_func},${_emulation},${_vale_id}"
     [ -n "${_mac}" ] && _devices="${_devices},mac=${_mac}"
 
     _func=$((_func + 1))

--- a/sample-templates/config.sample
+++ b/sample-templates/config.sample
@@ -94,6 +94,17 @@ wired_memory="no"
 #
 hostbridge=""
 
+# hostbridge_slot
+# The slot for a hostbridge for the guest. By default is 0.
+# This is usually configured at slot 0, and is required by most guest operating systems.
+#
+hostbridge_slot="0"
+
+# lpc_slot
+# The slot for a LPC PCI-ISA bridge for the guest. By default is 31.
+#
+lpc_slot="31"
+
 # ignore_bad_msr
 # Instruct bhyve to ignore accesses to model specific registers
 # that are not implemented in the current CPU.
@@ -215,6 +226,12 @@ disk0_name="disk0.img"
 #
 disk0_opts=""
 
+# disk0_slot
+# The slot for a disk device for the guest. 
+# If the slot is not specified - see disk_slot_start
+#
+disk0_slot="4"
+
 # disk0_size
 # When a new guest is created, vm will create a 20G disk image by
 # default. This option can be used to specify a different size
@@ -284,6 +301,12 @@ network0_mac=""
 #
 network0_span="no"
 
+# network0_slot
+# The slot for a network device for the guest. 
+# If the slot is not specified - see network_slot_start
+#
+network0_slot="11"
+
 # passthru0
 # Add a pass-through PCI device to the virtual machine. This allows the guest
 # to access a hardware device no differently than if it was running on bare
@@ -306,13 +329,19 @@ network0_span="no"
 #
 passthru0=""
 
-# start_slot
+# passthru_slot_start
+# The slot to start creating passthru PCI devices at inside the guest 
+# (if the slot is not specified). Default is 20.
+# 
+passthru_slot_start="20"
+
+# disk_slot_start
 # The slot to start creating devices at inside the guest. Note that
 # we create disk devices first, and some UEFI guests require disks to
 # be in slots 3-6. The default is 4, with 3 being left available for
 # an installation ISO
 #
-start_slot="4"
+disk_slot_start="4"
 
 # install_slot
 # The slot to use for an installation ISO. By default this is 3,
@@ -324,11 +353,22 @@ start_slot="4"
 #
 install_slot="3"
 
+# network_slot_start
+# The slot to start creating network devices at inside the guest. 
+# By default is 15.
+#
+network_slot_start="15"
+
 # virt_random
 # Set to any value other than [empty]/off/false/no/0 to create
 # a virtio-rnd device for the guest
 #
 virt_random=""
+
+# virt_random_slot
+# The slot for a virtio-rnd device for the guest. By default is 26.
+#
+virt_random_slot="26"
 
 # graphics
 # Set to a value other than [empty]/off/false/no/0 to enable
@@ -385,6 +425,16 @@ graphics_wait="auto"
 #
 graphics_vga="io"
 
+# vnc_password
+# Password for connecting to the VNC server.
+#
+vnc_password="password"
+
+# fbuf_slot
+# The slot for a framebuffer device for the guest. By default is 30.
+#
+fbuf_slot="30"
+
 # xhci_mouse
 # When graphics are enabled, a PS2 mouse is created by default. This
 # doesn't track very well, and can be replaced with an XHCI mouse
@@ -392,6 +442,34 @@ graphics_vga="io"
 # this mouse
 #
 xhci_mouse="yes"
+
+# xhci_slot
+# The slot for a xhci device for the guest. By default is 29.
+#
+xhci_slot="29"
+
+# sound
+# Set this option to yes in order to provide HD Audio Emulation to the guest.
+# Please see bhyve(8) for details.
+#
+sound="no"
+
+# sound_play
+# Set this to the desired audio output device of the host to the guest.
+# Defaults to '/dev/dsp0'
+#
+sound_play="/dev/dsp0"
+
+# sound_rec
+# Set this to the desired audio input device of the host to the guest.
+# If empty no audio input device is configured. Defaults to '' (empty)
+#
+sound_req=""
+
+# sound_slot
+# The slot for a audio output device for the guest. By default is 28.
+#
+sound_slot="28"
 
 # virt_console0
 # create up to 16 virtual console devices
@@ -405,6 +483,11 @@ xhci_mouse="yes"
 # FreeNAS bhyve-agent interface.
 #
 virt_console0="org.freenas.byhve-agent"
+
+# virt_console_slot
+# The slot for a virt_console device for the guest. By default is 27.
+#
+virt_console_slot="27"
 
 # grub_install0
 # use this to specify grub commands that should be run inside the

--- a/vm.8
+++ b/vm.8
@@ -1146,6 +1146,10 @@ There are also some special cases where you may require no hostbridge at all,
 which can be achieved using the
 .Sy none
 value.
+.It hostbridge_slot
+The slot for a hostbridge for the guest. By default is 0.
+.It lpc_slot
+The slot for a LPC PCI-ISA bridge for the guest. By default is 31.
 .It comports
 This option allows you to specify which com ports to create for the guest.
 The default is to create a single
@@ -1228,6 +1232,10 @@ Set this option to
 to instruct vm-bhyve to add the virtual network interface to the switch as a
 span port on the bridge.
 The default is to add the port to the switch as an ordinary bridge member.
+.It network0_slot
+The slot for a network device for the guest. 
+If the slot is not specified - see 
+.Sy network_slot_start
 .It disk0_type
 The emulation type for the first virtual disk.
 At least one virtual disk is required.
@@ -1302,6 +1310,10 @@ Multiple options can be specified, separated by a comma.
 Please see the
 .Xr bhyve 8
 man page for more details on supported options.
+.It disk0_slot
+The slot for a disk device for the guest. 
+If the slot is not specified - see 
+.Sy disk_slot_start
 .It disk0_size
 This setting can be specified in templates to set the size of this disk.
 When creating a guest,
@@ -1315,6 +1327,17 @@ command line option.
 NOTE: This setting is only supported in templates.
 It has no function in real guest configuration, and is not copied over when a
 new machine is provisioned.
+.It install_slot
+The slot to use for an installation ISO. By default this is 3, which is the 
+first available slot with the original UEFI firmware. Using this makes sure 
+the ISO is the first device, and leaves 4-6 available for hd devices.
+.It disk_slot_start
+The slot to start creating devices at inside the guest. Note that
+we create disk devices first, and some UEFI guests require disks to
+be in slots 3-6. The default is 4, with 3 being left available for
+an installation ISO
+.It network_slot_start
+The slot to start creating network devices at inside the guest. By default is 15.
 .It ahci_device_limit
 By default, all AHCI devices are added on their own controller in a unique
 slot/function.
@@ -1413,12 +1436,16 @@ same sequence as the original device.
 Please see
 .Lk https://wiki.freebsd.org/bhyve/pci_passthru
 for more details on how this works.
+.It passthru_slot_start
+The slot to start creating passthru PCI devices at inside the guest (if the slot is not specified). Default is 20.
 .It virt_random
 Set this option to
 .Sy yes
 if you want to create a
 .Sy virtio-rnd
 device for this guest.
+.It virt_random_slot
+The slot for a virtio-rnd device for the guest. By default is 26.
 .It graphics
 If set to yes, a frame buffer is added to the guest.
 This provides a graphical console that is accessible using VNC.
@@ -1477,12 +1504,18 @@ or
 Please see the
 .Xr bhyve 8
 man page for more details on this option.
+.It vnc_password
+Password for connecting to the VNC server.
+.It fbuf_slot
+The slot for a framebuffer device for the guest. By default is 30.
 .It xhci_mouse
 Set this option to
 .Sy yes
 in order to provide an XHCI mouse device to the guest.
 This tracks much better than the default PS2 mouse in VNC settings, although
 this mouse may not supported by older guests.
+.It xhci_slot
+The slot for a XHCI device for the guest. By default is 29.
 .It sound
 Set this option to
 .Sy yes
@@ -1496,6 +1529,8 @@ Set this to the desired audio output device of the host to the guest. Defaults t
 Set this to the desired audio input device of the host to the guest. If empty
 no audio input device is configured. Defaults to
 .Sy '' (empty)
+.It sound_slot
+The slot for a audio output device for the guest. By default is 28.
 .It virt_consoleX
 Allows the creation of up to 16 virtio-console devices in the guest. The value
 to this option can be
@@ -1507,6 +1542,8 @@ name
 .Sy org.freenas.bhyve-agent
 can be useful, as it ties in with utilities written for the FreeNAS
 bhyve-agent interface.
+.It virt_console_slot
+The slot for a virt_console device for the guest. By default is 27.
 .It zfs_dataset_opts
 This allows you to specify one or more ZFS properties to set on the dataset
 when a guest is created.


### PR DESCRIPTION
When adding a new disk, network device or passthru pci device to the configuration - after restarting the virtual machine, the numbers of all other PCI devices increase by +1
for Windows, this is a "new device", it has to be configured again. The network interface loses all the parameters of the ip mask gateway and so on.
I have added parameters to the configuration file:
hostbridge_slot
install_slot
disk_slot_start
diskX_slot
network_slot_start
networkX_slot
passthru_slot_start
virt_random_slot
virt_console_slot
sound_slot
xhci_slot
fbuf_slot
lpc_slot
allowing you to explicitly specify the PCI slot number for important devices and they remained fixed
